### PR TITLE
README update change bounds attribute to geometry and adding to data …

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ variables:
   double lat(instance) ;
     lat:units = "degrees_north" ;
     lat:standard_name = "latitude" ;
-    lat:bounds = "geometry_container" ;
+    lat:geometry = "geometry_container" ;
   double lon(instance) ;
     lon:units = "degrees_east" ;
     lon:standard_name = "longitude" ;
-    lon:bounds = "geometry_container" ;
+    lon:geometry = "geometry_container" ;
   int crs ;
     crs:grid_mapping_name = "latitude_longitude" ;
     crs:longitude_of_prime_meridian = 0.0 ;
@@ -149,11 +149,11 @@ variables:
     geometry_container:geometry_type = "multipolygon" ;
     geometry_container:node_count = "node_count"; // variable containing count of nodes per geometry -- may span multiple parts.
     geometry_container:part_node_count = "part_node_count" ; // variable containing count of nodes per part -- not required for single part geometry types.
-    geometry_container:polygon_ring_type = "polygon_ring_type" ; // Variable indicating if parts are holes or not -- not required unless polygons with holes are present.
+    geometry_container:outside_ring = "outside_ring" ; // Variable indicating if parts are holes or not -- not required unless polygons with holes are present.
     geometry_container:node_coordinates = "x y" ; // variables containing spatial node data.
   int node_count(instance); // count of coordinates in each instance geometry
   int part_node_count(part) ; // count of coordinates in each geometry part
-  int polygon_ring_type(part) ; // type of each geometry part
+  int outside_ring(part) ; // type of each geometry part
   double x(node) ;
     x:units = "degrees_east" ;
     x:standard_name = "longitude" ; // or projection_x_coordinate
@@ -165,6 +165,7 @@ variables:
   double someData(instance, time) ;
     someData:coordinates = "time lat lon" ;
     someData:grid_mapping = "crs" ;
+    someData:geometry = "geometry_container" ;
 // global attributes:
     :Conventions = "CF-1.8" ;
     :featureType = "timeSeries" ;
@@ -205,9 +206,9 @@ Starting from the time series featureType:
 2) See the `timeSeries` featureType  
 3) Find the `timeseries_id` `cf_role`  
 4) Find the `coordinates` attribute of element variables for the instance dimension  
-5) See the `bounds` attribute of the auxiliary coordinate variable  
-6) See the `geometry_type` in the variable referenced by `bounds`  
-7) Iterate over geometries found in the `node_coordinates` variable. Geometries are found using the `node_count` variable. Geometry parts are found using the `part_node_count` and `polygon_ring_type` variables.
+5) See the `geometry` attribute of the element variable or auxiliary coordinate variable  
+6) See the `geometry_type` in the variable referenced by by the `geometry` attribute  
+7) Iterate over geometries found in the `node_coordinates` variable. Geometries are found using the `node_count` variable. Geometry parts are found using the `part_node_count` and `outside_ring` variables.
 
 Or, without reference to the timeSeries:
 


### PR DESCRIPTION
…variable and change polygon_ring_type to outside_ring

These changes are per Jonathan's review on the CF email list. The "outside_ring" name reflects that what we are saying 1/0 is a binary true/false flag.

I think we should allow `geometry` to be an attribute of any data variable (auxiliary coordinate or regular data). Software that sees it would assume that the dimension the `node_count` is defined on is the shared dimension between the set of geometry and the variable carrying the `geometry` attribute.